### PR TITLE
Update to CyaSSL 2.0.6

### DIFF
--- a/build/libcyassl.c
+++ b/build/libcyassl.c
@@ -1,8 +1,7 @@
-#include <config.h>
-#include <types.h>
-#include <ctc_hmac.h>
-#include <ctc_aes.h>
-#include <random.h>
+#include <cyassl/ctaocrypt/types.h>
+#include <cyassl/ctaocrypt/hmac.h>
+#include <cyassl/ctaocrypt/aes.h>
+#include <cyassl/ctaocrypt/random.h>
 
 int main (void)
 {

--- a/configure.sh
+++ b/configure.sh
@@ -42,10 +42,8 @@ makl_add_var_mk "LDFLAGS" "\$(LIBZ_LDFLAGS)"
 # We just need the "crypto" side of OpenSSL.
 makl_optional 1 "lib" "openssl" "" "-lcrypto"
 
-# CyaSSL default install goes to /usr/local/cyassl/{include,lib}.
-CYASSL_BASE="/usr/local/cyassl"
-makl_optional 1 "lib" "cyassl" \
-                  "-I${CYASSL_BASE}/include" "-L${CYASSL_BASE}/lib -lcyassl"
+# CyaSSL default install goes to /usr/local{include/cyassl,lib}.
+makl_optional 1 "lib" "cyassl" "" "-lcyassl"
 
 # Binary dependencies (for bindings)
 makl_optional 1 "featx" "swig"

--- a/src/cyassl_drv.c
+++ b/src/cyassl_drv.c
@@ -1,9 +1,8 @@
-#include <config.h>
-#include <types.h>
-#include <ctc_hmac.h>
-#include <ctc_aes.h>
-#include <random.h>
-#include <coding.h>
+#include <cyassl/ctaocrypt/types.h>
+#include <cyassl/ctaocrypt/hmac.h>
+#include <cyassl/ctaocrypt/aes.h>
+#include <cyassl/ctaocrypt/random.h>
+#include <cyassl/ctaocrypt/coding.h>
 
 #include "cyassl_drv.h"
 #include "utils.h"


### PR DESCRIPTION
This commit updates libscs to be used with the most recent version of CyaSSL, 2.0.6.  As of version 2.0.2, the CyaSSL header structure and installation location changed.
